### PR TITLE
Creational Design pattern

### DIFF
--- a/covasim/run.py
+++ b/covasim/run.py
@@ -138,7 +138,7 @@ class MultiSim(cvb.FlexPretty):
 
         return
 
-
+dafttttttt
     def run(self, reduce=False, combine=False, **kwargs):
         '''
         Run the actual sims

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -1,5 +1,5 @@
 '''
-Functions and classes for running multiple Covasim runs.
+Functions and classes for running multiple Covasim runs.Will Use Factory Design Pattern to be called from one Class
 '''
 
 #%% Imports
@@ -31,6 +31,38 @@ def make_metapars():
         verbose   = cvo.verbose,
     )
     return metapars
+
+class PlotFactory():
+
+    '''
+    Factory class to allow all the simulations to go through
+    this class in this file instead of going through each method seperatly
+    '''
+    def run(self, reduce=False, combine=False, **kwargs):
+        '''
+        Run the actual sims
+
+        '''
+        # Handle which sims to use -- same as init_sims()
+        if self.sims is None:
+            sims = self.base_sim
+        else:
+            sims = self.sims
+
+        # Run
+        kwargs = sc.mergedicts(self.run_args, kwargs)
+        self.sims = multi_run(sims, **kwargs)
+
+        # Reduce or combine
+        if reduce:
+            self.reduce()
+        elif combine:
+            self.combine()
+
+        return self
+
+
+
 
 
 class MultiSim(cvb.FlexPretty):

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -170,7 +170,7 @@ class MultiSim(cvb.FlexPretty):
 
         return
 
-dafttttttt
+""
     def run(self, reduce=False, combine=False, **kwargs):
         '''
         Run the actual sims

--- a/covasim/sim.py
+++ b/covasim/sim.py
@@ -1281,7 +1281,7 @@ class Sim(cvb.BaseSim):
 
         New in version 2.1.0: argument passing, date_args, and mpl_args
         '''
-        fig = cvplt.plot_sim(sim=self, *args, **kwargs)
+        fig = cvplt.PlotFactory(sim=self, *args, **kwargs)
         return fig
 
 
@@ -1301,7 +1301,7 @@ class Sim(cvb.BaseSim):
             sim = cv.Sim().run()
             sim.plot_result('r_eff')
         '''
-        fig = cvplt.plot_result(sim=self, key=key, *args, **kwargs)
+        fig = cvplt.PlotFactory(sim=self, key=key, *args, **kwargs)
         return fig
 
 
@@ -1458,7 +1458,7 @@ def demo(preset=None, to_plot=None, scens=None, run_args=None, plot_args=None, *
     if not preset:
         sim = Sim(**kwargs)
         sim.run(**run_args)
-        sim.plot(**plot_args)
+        sim.PlotFactory(**plot_args)
         return sim
 
     elif preset == 'full':
@@ -1488,9 +1488,9 @@ def demo(preset=None, to_plot=None, scens=None, run_args=None, plot_args=None, *
             sims = [Sim(pars, **{scenpar:val}, label=label) for label,val in scenval.items()]
             msim = cvr.MultiSim(sims)
             msim.run(**run_args)
-            msim.plot(**plot_args)
+            msim.PlotFactory(**plot_args)
             msim.median()
-            msim.plot(**plot_args)
+            msim.PlotFactory(**plot_args)
             return msim
 
     else:


### PR DESCRIPTION
Intro:

We use the Factory pattern to create an object without exposing the creation logic to the client and refer to a newly created object using a common interface.  The factory method lets a class defer instantiates to subclasses. It lets the subclasses decide which class to instantiate.

Problem:

There are many methods in the plotting.py that keep repeating their iterations when a simulation is called. By using the factory design pattern, we can create a new plotting factory class to create the objects that the simulation calls. This means that instead of calling new methods for Create_figs, Create_subplots, title_grid_legend , we can group them and combine them into a general method called plot.

Solution/Changes:

Now we can call for this factory class, so that the client can simply run the plotting method that is combined together from the factory class, instead of the simulation running each method separately on the plotting file. 
