### PR TITLE
Creating the Adapter class

### DIFF
--- a/covasim/analysis.py
+++ b/covasim/analysis.py
@@ -22,6 +22,18 @@ except ImportError as E: # pragma: no cover
 
 
 __all__ = ['Analyzer', 'snapshot', 'age_histogram', 'daily_age_stats', 'daily_stats', 'Fit', 'Calibration', 'TransTree']
+'''
+Create the adapter class that will actually implement the interface in intervention
+
+'''
+class Adapter():
+
+    def __init__(self,label=None):
+        self.Adapter = Adapter:
+
+    def request(self, label=None):
+
+
 
 
 class Analyzer(sc.prettyobj):
@@ -37,17 +49,17 @@ class Analyzer(sc.prettyobj):
         label (str): a label for the Analyzer (used for ease of identification)
     '''
 
-    def __init__(self, label=None):
-        if label is None:
-            label = self.__class__.__name__ # Use the class name if no label is supplied
-        self.label = label # e.g. "Record ages"
-        self.initialized = False
-        self.finalized = False
-        return
+            def __init__(self, label=None):
+                    if label is None:
+                        label = self.__class__.__name__ # Use the class name if no label is supplied
+                        self.label = label # e.g. "Record ages"
+                        self.initialized = False
+                        self.finalized = False
+                        return
 
-    def __call__(self, *args, **kwargs):
+        def __call__(self, *args, **kwargs):
         # Makes Analyzer(sim) equivalent to Analyzer.apply(sim)
-        if not self.initialized:
+            if not self.initialized:
             errormsg = f'Analyzer (label={self.label}, {type(self)}) has not been initialized'
             raise RuntimeError(errormsg)
         return self.apply(*args, **kwargs)
@@ -2011,4 +2023,3 @@ class TransTree(Analyzer):
 
 
         return fig
-

--- a/covasim/interventions.py
+++ b/covasim/interventions.py
@@ -40,6 +40,7 @@ def find_day(arr, t=None, interv=None, sim=None, which='first'):
 
     New in version 2.1.2: arr can be a function with arguments interv and sim.
     '''
+
     if callable(arr):
         arr = arr(interv, sim)
         arr = sc.promotetoarray(arr)
@@ -55,30 +56,43 @@ def find_day(arr, t=None, interv=None, sim=None, which='first'):
         raise ValueError(errormsg)
     return inds
 
+'''
+Defines the Adapter function that allows interventions to access the analysis class
+'''
+            def __init__(self, label )
 
-def preprocess_day(day, sim):
-    '''
-    Preprocess a day: leave it as-is if it's a function, or try to convert it to
-    an integer if it's anything else.
-    '''
-    if callable(day): # If it's callable, leave it as-is
+
+    self.label = Adapter:
+
+Adapter = Intervention(analysis()):
+
+Adapter.Analyzer():
+
+
+
+    def preprocess_day(day, sim):
+        '''
+        Preprocess a day: leave it as-is if it's a function, or try to convert it to
+        an integer if it's anything else.
+        '''
+        if callable(day): # If it's callable, leave it as-is
         return day
-    else:
+        else:
         day = sim.day(day) # Otherwise, convert it to an int
     return day
 
 
-def get_day(day, interv=None, sim=None):
+    def get_day(day, interv=None, sim=None):
     '''
-    Return the day if it's an integer, or call it if it's a function.
+        Return the day if it's an integer, or call it if it's a function.
     '''
-    if callable(day):
+if callable(day):
         return day(interv, sim) # If it's callable, call it
     else:
         return day # Otherwise, leave it as-is
 
 
-def process_days(sim, days, return_dates=False):
+        def process_days(sim, days, return_dates=False):
     '''
     Ensure lists of days are in consistent format. Used by change_beta, clip_edges,
     and some analyzers. If day is 'end' or -1, use the final day of the simulation.
@@ -1627,4 +1641,3 @@ class vaccinate_num(BaseVaccination):
             self._scheduled_doses[sim.t+self.p['interval']].update(first_dose_inds)
 
         return np.concatenate([scheduled, first_dose_inds])
-


### PR DESCRIPTION
Intro:

I will implement the adapter pattern to enable objects with different interfaces to communicate with each other. One example would be the analysis.py and interventions.py. Both files have a separate interface when being called and we can use the adapter pattern whenever we want unrelated classes to work together in a single program. The two interfaces are not compatible which calls for an adapter design pattern to be implemented.

Solution:

The adapter pattern will let these two classes work together and create compatible interfaces. The adapter class will take no arguments and return nothing in the implementation. The client who wants to call the method signature through analysis.py in interventions.py will now be able to with the adapter wrapper class. 